### PR TITLE
With title

### DIFF
--- a/src/library/Message.php
+++ b/src/library/Message.php
@@ -30,6 +30,7 @@ class Message implements JsonSerializable
      */
     private array $actions = [];
 
+    private ?string $title;
     private string $body;
 
     /**
@@ -54,9 +55,16 @@ class Message implements JsonSerializable
      */
     private ?array $vibrate = null;
 
-    public function __construct(string $body)
+    public function __construct(/**string $title , */ string $body)
     {
-        $this->body = $body;
+        if (func_num_args() !== 2) {
+            @trigger_error('Calling the constructor only with the body is deprecated since 1.1. Pass it as the second argument and provide the message title as the first argument instead.', \E_USER_DEPRECATED);
+            $this->title = null;
+            $this->body = $body;
+        } else {
+            $this->title = func_get_arg(0);
+            $this->body = func_get_arg(1);
+        }
     }
 
     public function toString(): string
@@ -133,6 +141,11 @@ class Message implements JsonSerializable
     public function getTag(): ?string
     {
         return $this->tag;
+    }
+
+    public function getTitle(): ?string
+    {
+        return $this->title;
     }
 
     public function getTimestamp(): ?int

--- a/src/library/Message.php
+++ b/src/library/Message.php
@@ -14,6 +14,9 @@ declare(strict_types=1);
 namespace WebPush;
 
 use function count;
+use const E_USER_DEPRECATED;
+use function func_get_args;
+use function func_num_args;
 use function is_array;
 use JsonSerializable;
 use function Safe\json_encode;
@@ -54,16 +57,22 @@ class Message implements JsonSerializable
      * @var array<int, int>|null
      */
     private ?array $vibrate = null;
+    private bool $useNewStructure;
 
-    public function __construct(/**string $title , */ string $body)
+    public function __construct(/*string $title , */ string $body/*, bool $useNewStructure = false*/)
     {
-        if (func_num_args() !== 2) {
-            @trigger_error('Calling the constructor only with the body is deprecated since 1.1. Pass it as the second argument and provide the message title as the first argument instead.', \E_USER_DEPRECATED);
+        //dump(func_get_args());
+        if (func_num_args() < 2) {
+            @trigger_error('Calling the constructor only with the body is deprecated since 1.1 and will be removed in v2.0. Pass it as the second argument and provide the message title as the first argument instead.', E_USER_DEPRECATED);
             $this->title = null;
             $this->body = $body;
         } else {
             $this->title = func_get_arg(0);
             $this->body = func_get_arg(1);
+        }
+        $this->useNewStructure = 3 === func_num_args() ? func_get_arg(2) : false;
+        if (false === $this->useNewStructure) {
+            @trigger_error('The current flat structure is deprecated since v1.1 and will be removed in v2.0. Please set the third argument as true to use the new structure instead.', E_USER_DEPRECATED);
         }
     }
 
@@ -72,9 +81,9 @@ class Message implements JsonSerializable
         return json_encode($this, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
     }
 
-    public static function create(string $body): self
+    public static function create(/*string $title , */ string $body/*, bool $useNewStructure = false*/): self
     {
-        return new self($body);
+        return new self(...func_get_args());
     }
 
     /**
@@ -295,7 +304,29 @@ class Message implements JsonSerializable
      */
     public function jsonSerialize(): array
     {
-        $r = array_filter(get_object_vars($this), static function ($v): bool {
+        $properties = get_object_vars($this);
+        unset($properties['useNewStructure']);
+
+        if (true === $this->useNewStructure) {
+            unset($properties['title']);
+
+            return [
+                'title' => $this->title,
+                'options' => $this->getOptions($properties),
+            ];
+        }
+
+        return $this->getOptions($properties);
+    }
+
+    /**
+     * @param array<string, mixed> $properties
+     *
+     * @return array<string, mixed>
+     */
+    private function getOptions(array $properties): array
+    {
+        $r = array_filter($properties, static function ($v): bool {
             if (is_array($v) && 0 === count($v)) {
                 return false;
             }

--- a/src/library/Message.php
+++ b/src/library/Message.php
@@ -34,7 +34,7 @@ class Message implements JsonSerializable
     private array $actions = [];
 
     private ?string $title;
-    private string $body;
+    private ?string $body;
 
     /**
      * @var mixed|null
@@ -59,7 +59,7 @@ class Message implements JsonSerializable
     private ?array $vibrate = null;
     private bool $useNewStructure;
 
-    public function __construct(/*string $title , */ string $body/*, bool $useNewStructure = false*/)
+    public function __construct(/*string $title , */ ?string $body = null/*, bool $useNewStructure = false*/)
     {
         //dump(func_get_args());
         if (func_num_args() < 2) {
@@ -70,6 +70,10 @@ class Message implements JsonSerializable
             $this->title = func_get_arg(0);
             $this->body = func_get_arg(1);
         }
+        if (null !== $this->body) {
+            @trigger_error('Passing the body in the constructor is deprecated since 1.1 and will be removed in v2.0. Please set it to null and use the method "withBody" instead.', E_USER_DEPRECATED);
+        }
+
         $this->useNewStructure = 3 === func_num_args() ? func_get_arg(2) : false;
         if (false === $this->useNewStructure) {
             @trigger_error('The current flat structure is deprecated since v1.1 and will be removed in v2.0. Please set the third argument as true to use the new structure instead.', E_USER_DEPRECATED);
@@ -81,7 +85,7 @@ class Message implements JsonSerializable
         return json_encode($this, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
     }
 
-    public static function create(/*string $title , */ string $body/*, bool $useNewStructure = false*/): self
+    public static function create(/*string $title , */ ?string $body = null/*, bool $useNewStructure = false*/): self
     {
         return new self(...func_get_args());
     }
@@ -94,7 +98,7 @@ class Message implements JsonSerializable
         return $this->actions;
     }
 
-    public function getBody(): string
+    public function getBody(): ?string
     {
         return $this->body;
     }
@@ -190,6 +194,20 @@ class Message implements JsonSerializable
     public function auto(): self
     {
         $this->dir = 'auto';
+
+        return $this;
+    }
+
+    public function withTitle(string $title): self
+    {
+        $this->title = $title;
+
+        return $this;
+    }
+
+    public function withBody(string $body): self
+    {
+        $this->body = $body;
 
         return $this;
     }

--- a/tests/Library/Unit/MessageTest.php
+++ b/tests/Library/Unit/MessageTest.php
@@ -30,10 +30,9 @@ final class MessageTest extends TestCase
      */
     public function createSimpleMessage(): void
     {
-        $message = Message::create('BODY')
-        ;
+        $message = Message::create();
 
-        static::assertEquals('BODY', $message->getBody());
+        static::assertNull($message->getBody());
         static::assertNull($message->getTitle());
         static::assertNull($message->getTimestamp());
         static::assertNull($message->getTag());
@@ -49,7 +48,7 @@ final class MessageTest extends TestCase
         static::assertNull($message->getRenotify());
         static::assertNull($message->isInteractionRequired());
 
-        $expectedJson = '{"body":"BODY"}';
+        $expectedJson = '[]';
         static::assertEquals($expectedJson, $message->toString());
         static::assertEquals($expectedJson, json_encode($message, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
     }


### PR DESCRIPTION
This PR adds the notification `title` property and fixes #5. It also allows the body to be `null`.

As this property should be required, a deprecation warning is sent if not set.
```php
// BEFORE
        $message = Message::create('BODY')
            ->withTag('TAG')
            ->withTimestamp(1604141464)
            ->withLang('en-GB')
            ->withImage('https://image.svg')
            ->withBadge('BADGE')
            ->withIcon('https://icon.ico')
            ->withData(['foo' => 'BAR', 1, 2, 3])
            ->addAction($action)
            ->vibrate(300, 10, 200, 10, 500)
        ;

//AFTER

        $message = Message::create('TITLE', 'BODY')
            ->withTag('TAG')
            ->withTimestamp(1604141464)
            ->withLang('en-GB')
            ->withImage('https://image.svg')
            ->withBadge('BADGE')
            ->withIcon('https://icon.ico')
            ->withData(['foo' => 'BAR', 1, 2, 3])
            ->addAction($action)
            ->vibrate(300, 10, 200, 10, 500)
        ;

// OR 
        $message = Message::create('TITLE', null) // Null body
            ->withTag('TAG')
            ->withTimestamp(1604141464)
            ->withLang('en-GB')
            ->withImage('https://image.svg')
            ->withBadge('BADGE')
            ->withIcon('https://icon.ico')
            ->withData(['foo' => 'BAR', 1, 2, 3])
            ->addAction($action)
            ->vibrate(300, 10, 200, 10, 500)
        ;
```

**The title will be required for the v2.0.**

In addition, I adds a new way to render the serialized message so that it becomes easier to create a Notification object on client side.
The structure is exactly the same as the one showned on the page https://developer.mozilla.org/en-US/docs/Web/API/Notification/Notification#parameters

**The old structure is deprecated and will be the default one for the v2.0.**

```php
// BEFORE
        $message = Message::create('BODY')
            ->withTag('TAG')
            ->withTimestamp(1604141464)
            ->withLang('en-GB')
            ->withImage('https://image.svg')
            ->withBadge('BADGE')
            ->withIcon('https://icon.ico')
            ->withData(['foo' => 'BAR', 1, 2, 3])
            ->addAction($action)
            ->vibrate(300, 10, 200, 10, 500)
        ;
// {"badge":"BADGE","body":"BODY","data":{"foo":"BAR","0":1,"1":2,"2":3},"icon":"https://icon.ico","image":"https://image.svg","lang":"en-GB","tag":"TAG","timestamp":1604141464,"vibrate":[300,10,200,10,500]}

//AFTER
        $message = Message::create('TITLE', 'BODY', true)
            ->withTag('TAG')
            ->withTimestamp(1604141464)
            ->withLang('en-GB')
            ->withImage('https://image.svg')
            ->withBadge('BADGE')
            ->withIcon('https://icon.ico')
            ->withData(['foo' => 'BAR', 1, 2, 3])
            ->addAction($action)
            ->vibrate(300, 10, 200, 10, 500)
        ;
// {"title":"TITLE","options":{"badge":"BADGE","body":"BODY","data":{"foo":"BAR","0":1,"1":2,"2":3},"icon":"https://icon.ico","image":"https://image.svg","lang":"en-GB","tag":"TAG","timestamp":1604141464,"vibrate":[300,10,200,10,500]}}

```