### PR TITLE
Allow lcobucci/jwt to v4 or v5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -97,5 +97,8 @@
     "web-token/jwt-signature-algorithm-ecdsa": "Mandatory if you want to use VAPID using web-token/jwt-framework",
     "lcobucci/jwt": "Mandatory if you want to use VAPID using lcobucci/jwt",
     "psr/log-implementation": "Recommended to receive logs from the library"
-  }
+  },
+  "conflict": {
+    "lcobucci/jwt": "<4|>=5"
+  },
 }

--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
     "doctrine/orm": "^2.6",
     "friendsofphp/php-cs-fixer": "^3.0",
     "infection/infection": "^0.22",
-    "lcobucci/jwt": "^4.0",
+    "lcobucci/jwt": "^4.0|^5.0",
     "matthiasnoback/symfony-config-test": "^4.2",
     "matthiasnoback/symfony-dependency-injection-test": "^4.2",
     "nyholm/psr7": "^1.3",
@@ -85,7 +85,12 @@
     }
   },
   "config": {
-    "sort-packages": true
+    "sort-packages": true,
+    "allow-plugins": {
+      "rector/rector-installer": true,
+      "infection/extension-installer": true,
+      "php-http/discovery": true
+    }
   },
   "replace": {
     "spomky-labs/web-push-lib": "self.version",
@@ -97,8 +102,5 @@
     "web-token/jwt-signature-algorithm-ecdsa": "Mandatory if you want to use VAPID using web-token/jwt-framework",
     "lcobucci/jwt": "Mandatory if you want to use VAPID using lcobucci/jwt",
     "psr/log-implementation": "Recommended to receive logs from the library"
-  },
-  "conflict": {
-    "lcobucci/jwt": "<4|>=5"
-  },
+  }
 }

--- a/src/library/VAPID/LcobucciProvider.php
+++ b/src/library/VAPID/LcobucciProvider.php
@@ -68,7 +68,11 @@ final class LcobucciProvider implements JWSProvider, Loggable
     public function computeHeader(array $claims): Header
     {
         $this->logger->debug('Computing the JWS');
-        $signer = Sha256::create();
+        if (method_exists(Sha256::class, 'create')) {
+            $signer = Sha256::create();
+        } else {
+            $signer = new Sha256();
+        }
         $header = json_encode(['typ' => 'JWT', 'alg' => 'ES256'], self::JSON_OPTIONS);
         $payload = json_encode($claims, self::JSON_OPTIONS);
         $dataToSign = sprintf(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 1.0.x
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #... 
| License       | MIT

To use VAPID Header, we can install lcobucci/jwt. But if we run php >= 8.1, `composer req lcobucci/jwt` install the v5 of this lib.

In LcobucciProvider, Sha256::create() only works with lcobucci/jwt v4; in v5, this method doesn't exists anymore.

> Call to undefined method Lcobucci\JWT\Signer\Ecdsa\Sha256::create().

This PR force utilisation of the v4